### PR TITLE
Changed the type (target) of Worker Status Distribution

### DIFF
--- a/monitoring/grafana/dashboards/pangolin-render-farm.json
+++ b/monitoring/grafana/dashboards/pangolin-render-farm.json
@@ -289,7 +289,9 @@
         {
           "expr": "flamenco_worker_status",
           "refId": "A",
-          "legendFormat": "{{status}}"
+          "legendFormat": "{{status}}",
+          "instant": true,
+          "range": false
         }
       ],
       "options": {


### PR DESCRIPTION
Change to Instant instead of Range, this should fix 2 workers having 4 states.