### PR TITLE
Fix AudioContext leak in notifications.js, add resume guard and robust init (v2-dev)

### DIFF
--- a/pangolin-backend/src/main/resources/static/js/notifications.js
+++ b/pangolin-backend/src/main/resources/static/js/notifications.js
@@ -142,5 +142,9 @@ const notifications = (() => {
     return { init };
 })();
 
-// Initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', notifications.init);
+// Auto-initialize
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', notifications.init);
+} else {
+    notifications.init();
+}


### PR DESCRIPTION
Changes:

- Hoisted AudioContext to module-level so a single instance is created lazily on first play and reused for all subsequent sounds, eliminating the leak
-  Added audioContext.resume() before playback to handle browser auto-suspension (tabs backgrounded, periods of inactivity) — without this, a suspended context would silently fail to play
-  Added .catch() on resume() to surface failures as a console warning rather than an unhandled promise rejection
- Replaced DOMContentLoaded listener with readyState !== 'loading' guard, consistent with active-sessions.js, so init() is called correctly if the script loads after DOM is ready

Testing:

- Notification sound plays correctly on first render completion
- Sound continues to play correctly across multiple render completions in the same session
- No new AudioContext instances created after the first play